### PR TITLE
Change sparqlfile argument to hdtsparql to use two dashes

### DIFF
--- a/hdt-api/pom.xml
+++ b/hdt-api/pom.xml
@@ -8,7 +8,7 @@
 	<parent>
 	    <groupId>org.rdfhdt</groupId>
 	    <artifactId>hdt-java-parent</artifactId>
-	    <version>0.1.0-alpha</version>
+	    <version>0.1.1-alpha</version>
 	    <relativePath>../</relativePath>
 	</parent>
 

--- a/hdt-java-cli/pom.xml
+++ b/hdt-java-cli/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.rdfhdt</groupId>
         <artifactId>hdt-java-parent</artifactId>
-        <version>0.1.0-alpha</version>
+        <version>0.1.1-alpha</version>
     </parent>
 
     <dependencies>

--- a/hdt-java-core/pom.xml
+++ b/hdt-java-core/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.rdfhdt</groupId>
         <artifactId>hdt-java-parent</artifactId>
-        <version>0.1.0-alpha</version>
+        <version>0.1.1-alpha</version>
     </parent>
 	
     <licenses>

--- a/hdt-java-package/pom.xml
+++ b/hdt-java-package/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>org.rdfhdt</groupId>
     <artifactId>hdt-java-parent</artifactId>
-    <version>0.1.0-alpha</version>
+    <version>0.1.1-alpha</version>
   </parent>
 
   <dependencies>

--- a/hdt-jena/pom.xml
+++ b/hdt-jena/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>org.rdfhdt</groupId>
     <artifactId>hdt-java-parent</artifactId>
-    <version>0.1.0-alpha</version>
+    <version>0.1.1-alpha</version>
   </parent>
 
   <licenses>

--- a/hdt-jena/src/main/java/org/rdfhdt/hdtjena/cmd/HDTSparql.java
+++ b/hdt-jena/src/main/java/org/rdfhdt/hdtjena/cmd/HDTSparql.java
@@ -42,7 +42,7 @@ public class HDTSparql
     @Parameter(names = "--stream", description = "Output CONSTRUCT/DESCRIBE query results directly as they are generated")
     public boolean streamMode = false;
 
-    @Parameter(names = "-sparqlfile", description = "Name of the file with a SPARQL query to use")
+    @Parameter(names = "--sparqlfile", description = "Name of the file with a SPARQL query to use")
     public String sparqlQueryFileName;
 
     public String fileHDT;

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
     <artifactId>hdt-java-parent</artifactId>
     <packaging>pom</packaging>
     <name>RDF/HDT</name>
-    <version>0.1.0-alpha</version>
+    <version>0.1.1-alpha</version>
     <description>HDT (Header, Dictionary, Triples) is a compact data structure and binary
         serialization format for RDF that keeps big datasets compressed to save space while
         maintaining search and browse operations without prior decompression. This makes it an ideal


### PR DESCRIPTION
Change sparqlfile argument to hdtsparql to use two dashes instead of one. Bumped version to `0.1.1-alpha`.